### PR TITLE
Removed Xapian settings for 3.5

### DIFF
--- a/cfg.d/z_richtext.pl
+++ b/cfg.d/z_richtext.pl
@@ -1,11 +1,11 @@
 if ( EPrints->human_version =~ m/^3.4/ )
 {
 	$c->{deps}->{"ingredients/richtext"} = [ "ingredients/jquery" ];
-}
 
-#explicitly specify xapian indexing method
-$c->{xapian}->{indexing_methods} = {} unless defined $c->{xapian}->{indexing_methods};
-$c->{xapian}->{indexing_methods}->{'EPrints::MetaField::Richtext'} = 'text';
+	#explicitly specify xapian indexing method
+	$c->{xapian}->{indexing_methods} = {} unless defined $c->{xapian}->{indexing_methods};
+	$c->{xapian}->{indexing_methods}->{'EPrints::MetaField::Richtext'} = 'text';
+}
 
 # Define HTML entities to support HTML decoding of rich text strings
 # E.g. $value =~ s/([&<>"])/$c->{html_entities}->{$1}/g;


### PR DESCRIPTION
As EPrints 3.5 is removing Xapian search there is no reason to set the relevant settings, unless it is a 3.4 repo.

This is a sister PR to the approved core PR https://github.com/eprints/eprints3.5/pull/168.