### PR TITLE
Remove the (unstated) dependency on jQuery

### DIFF
--- a/plugins/EPrints/MetaField/Richtext.pm
+++ b/plugins/EPrints/MetaField/Richtext.pm
@@ -49,9 +49,8 @@ sub render_input_field_actual
 
 	my $frag = $self->SUPER::render_input_field_actual( @_[1..$#_] );
 
-	#$frag->appendChild( $session->make_element( "script", src => "//code.jquery.com/jquery-1.12.4.js" ) );
 	$frag->appendChild( $session->make_element( "script", src=> "/javascript/tinymce.min.js" ) );
-	$frag->appendChild( $session->make_javascript( 'jQuery( document ).ready(function($){ initTinyMCE("#' . $basename .'"); } );' ) );
+	$frag->appendChild( $session->make_javascript( "document.addEventListener('DOMContentLoaded', (_) => { initTinyMCE('#$basename'); } );" ) );
 
 	return $frag;
 }


### PR DESCRIPTION
The only thing richtext used jQuery for was this `.ready` which can be trivially replaced with a `DOMContentLoaded` listener, allowing richtext to work without `jquery4eprints`.

Fixes #8.