### PR TITLE
Prevent links being converted to relative links

### DIFF
--- a/static/javascript/auto/60_richtext.js
+++ b/static/javascript/auto/60_richtext.js
@@ -6,6 +6,7 @@ var initTinyMCE = function(id){
 		height: 500,
 		width: 700,
 		menubar: false,
+		relative_url: false,
 		toolbar: 'undo redo | insert | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
 		plugins: [
 			'advlist autolink lists link image charmap print preview anchor',

--- a/static/javascript/auto/60_richtext.js
+++ b/static/javascript/auto/60_richtext.js
@@ -7,6 +7,7 @@ var initTinyMCE = function(id){
 		width: 700,
 		menubar: false,
 		relative_url: false,
+		remove_script_host: false,
 		toolbar: 'undo redo | insert | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
 		plugins: [
 			'advlist autolink lists link image charmap print preview anchor',


### PR DESCRIPTION
This will need similar changes in 3.5 core in order to work with the JSON richtext.

Fixes #6.