### PR TITLE
Don't allow richtext fields to be reordered

### DIFF
--- a/plugins/EPrints/MetaField/Richtext.pm
+++ b/plugins/EPrints/MetaField/Richtext.pm
@@ -92,6 +92,17 @@ sub render_single_value
         return $body;
 }
 
+sub get_property_defaults
+{
+	my( $self ) = @_;
+	my %defaults = $self->SUPER::get_property_defaults;
+
+	# Don't show the options to re-order richtext fields (as it is majorly broken)
+	$defaults{input_ordered} = 0;
+
+	return %defaults;
+}
+
 ######################################################################
 1;
 


### PR DESCRIPTION
As found in https://github.com/eprints/eprints3.5/pull/231#issuecomment-3365264944, re-ordering richtext fields causes a multitude of issues, ranging from the fields themselves being cleared to changes to all other richtexts on the page not actually saving.

To prevent this rather major footgun (in the unusual edge case of a `multiple` richtext) this makes the executive decision to just prevent the re-order buttons from even showing up.

While this isn't as good as properly supporting the AJAX update, there are some very strange TinyMCE quirks that are causing this that likely aren't worth figuring out. This could be reconsidered with a very concrete use case however given that it has never worked this is unlikely to be an immediate issue.

Possible follow-up issue: In 3.5 this also prevents the new 'Clear Row' button from appearing (eprints/eprints3.5#218) however this feels like it is probably just an implementation quirk and that button should actually be connected to the `input_ordered` option (if necessary it could maybe have its own option though).